### PR TITLE
Add auto remove flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: '1.12.3'
         otp-version: '24.1'

--- a/lib/docker/api/containers.ex
+++ b/lib/docker/api/containers.ex
@@ -86,7 +86,12 @@ defmodule Docker.Api.Containers do
       ExposedPorts: exposed_ports_config,
       Env: env_config,
       Labels: container_config.labels,
-      HostConfig: %{PortBindings: port_bindings_config, Privileged: container_config.privileged, Binds: volume_bindings}
+      HostConfig: %{
+        AutoRemove: container_config.auto_remove,
+        PortBindings: port_bindings_config,
+        Privileged: container_config.privileged,
+        Binds: volume_bindings
+      }
     }
     |> remove_nil_values
   end

--- a/lib/docker/container.ex
+++ b/lib/docker/container.ex
@@ -14,7 +14,8 @@ defmodule Docker.Container do
     wait_strategy: nil,
     privileged: false,
     bind_mounts: [],
-    labels: %{}
+    labels: %{},
+    auto_remove: true
   ]
 
   @doc """
@@ -26,8 +27,9 @@ defmodule Docker.Container do
   - `cmd` sets the command to run in the container
   - `environment` sets the environment variables for the container
   - `exposed_ports` sets the ports to expose to the host
-  - `privileged` indicates whether the container should run in privileged mode
+  - `privileged` indicates whether the container should run in privileged mode (default false)
   - `wait_strategy` sets the strategy to adopt to determine whether the container is ready for use
+  - `auto_remove` whether to automatically remove the container after it's stopped (default true)
 
   """
   def new(image, opts \\ []) do
@@ -42,7 +44,8 @@ defmodule Docker.Container do
       environment: opts[:environment] || %{},
       exposed_ports: exposed_ports,
       privileged: opts[:privileged] || false,
-      wait_strategy: opts[:wait_strategy]
+      wait_strategy: opts[:wait_strategy],
+      auto_remove: opts[:auto_remove] || true
     }
   end
 

--- a/test/excontainers/auto_remove_test.exs
+++ b/test/excontainers/auto_remove_test.exs
@@ -14,5 +14,4 @@ defmodule Excontainers.AutoRemoveTest do
 
     refute container_exists?(container_id)
   end
-
 end

--- a/test/excontainers/auto_remove_test.exs
+++ b/test/excontainers/auto_remove_test.exs
@@ -1,11 +1,9 @@
 defmodule Excontainers.AutoRemoveTest do
   use ExUnit.Case, async: true
 
-  alias Excontainers.ResourcesReaper
   import Support.DockerTestUtils
 
   @sample_container Docker.Container.new("alpine", cmd: ~w(sleep infinity), auto_remove: true)
-  @expected_timeout_seconds 15
 
   test "when using auto_remove, the container is removed when it's stopped" do
     {:ok, container_id} = Docker.Containers.run(@sample_container)
@@ -17,8 +15,4 @@ defmodule Excontainers.AutoRemoveTest do
     refute container_exists?(container_id)
   end
 
-  defp container_exists?(container_id) do
-    {all_containers, _exit_code = 0} = System.cmd("docker", ~w(ps -a))
-    all_containers =~ short_id(container_id)
-  end
 end

--- a/test/excontainers/auto_remove_test.exs
+++ b/test/excontainers/auto_remove_test.exs
@@ -1,0 +1,24 @@
+defmodule Excontainers.AutoRemoveTest do
+  use ExUnit.Case, async: true
+
+  alias Excontainers.ResourcesReaper
+  import Support.DockerTestUtils
+
+  @sample_container Docker.Container.new("alpine", cmd: ~w(sleep infinity), auto_remove: true)
+  @expected_timeout_seconds 15
+
+  test "when using auto_remove, the container is removed when it's stopped" do
+    {:ok, container_id} = Docker.Containers.run(@sample_container)
+
+    assert container_exists?(container_id)
+
+    assert :ok = Docker.Containers.stop(container_id)
+
+    refute container_exists?(container_id)
+  end
+
+  defp container_exists?(container_id) do
+    {all_containers, _exit_code = 0} = System.cmd("docker", ~w(ps -a))
+    all_containers =~ short_id(container_id)
+  end
+end

--- a/test/excontainers/resources_reaper_test.exs
+++ b/test/excontainers/resources_reaper_test.exs
@@ -4,7 +4,7 @@ defmodule Excontainers.ResourcesReaperTest do
   alias Excontainers.ResourcesReaper
   import Support.DockerTestUtils
 
-  @sample_container Docker.Container.new("alpine", cmd: ~w(sleep infinity))
+  @sample_container Docker.Container.new("alpine", cmd: ~w(sleep infinity), auto_remove: false)
   @expected_timeout_seconds 15
 
   test "when it terminates, reaps all registered resources after a timeout" do

--- a/test/excontainers/resources_reaper_test.exs
+++ b/test/excontainers/resources_reaper_test.exs
@@ -29,9 +29,4 @@ defmodule Excontainers.ResourcesReaperTest do
 
     :timer.sleep(time_to_wait_ms)
   end
-
-  defp container_exists?(container_id) do
-    {all_containers, _exit_code = 0} = System.cmd("docker", ~w(ps -a))
-    all_containers =~ short_id(container_id)
-  end
 end

--- a/test/support/docker_test_utils.ex
+++ b/test/support/docker_test_utils.ex
@@ -37,6 +37,11 @@ defmodule Support.DockerTestUtils do
     running_containers_output =~ short_id(container_id)
   end
 
+  def container_exists?(container_id) do
+    {all_containers, _exit_code = 0} = System.cmd("docker", ~w(ps -a))
+    all_containers =~ short_id(container_id)
+  end
+
   def image_exists?(image_name) do
     {stdout, _exit_code = 0} = System.cmd("docker", ["images", "-q", image_name])
 


### PR DESCRIPTION
This PR adds the auto_remove flag (enabled by default). This flag signals docker to remove the container when it's stopped. In this way, when you don't use the reaper you at least don't keep all the successfully stopped containers.