### PR TITLE
Trap exits in container

### DIFF
--- a/lib/excontainers/container.ex
+++ b/lib/excontainers/container.ex
@@ -24,6 +24,7 @@ defmodule Excontainers.Container do
 
   @impl true
   def init(config) do
+    Process.flag(:trap_exit, true)
     {:ok, container_id} = Docker.Containers.run(config)
 
     {:ok, %__MODULE__{config: config, container_id: container_id}}


### PR DESCRIPTION
This PR traps exits in the `Container` genserver, otherwise the `terminate/2` callback won't be called.