### PR TITLE
Retry fetching mapped host port when a container is created

### DIFF
--- a/lib/docker/container_state.ex
+++ b/lib/docker/container_state.ex
@@ -37,6 +37,8 @@ defmodule Docker.ContainerState do
 
   defp host_port(nil), do: nil
 
+  defp host_port([]), do: nil
+
   defp host_port(ports) do
     ports
     |> Enum.at(0)


### PR DESCRIPTION
I've been running into a race condition where the host port mapping is not available right after a container is created. Attempting to inspect the container too quickly results in a JSON blob that looks roughly like:

```elixir
  "NetworkSettings" => %{
    "Ports" => %{
      "8080/tcp" => []
  },
```

which in turn results in the following exception:

```
09:48:03.330 module=gen_server [error] GenServer #PID<0.554.0> terminating
** (BadMapError) expected a map, got: nil
    (elixir 1.16.3) lib/map.ex:535: Map.get(nil, "HostPort", nil)
    (excontainers 0.3.0) lib/docker/container_state.ex:34: anonymous fn/1 in Docker.ContainerState.port_mapping/1
    (elixir 1.16.3) lib/enum.ex:1708: anonymous fn/3 in Enum.map/2
    (stdlib 4.3.1.4) maps.erl:411: :maps.fold_1/3
    (elixir 1.16.3) lib/enum.ex:2540: Enum.map/2
    (excontainers 0.3.0) lib/docker/container_state.ex:34: Docker.ContainerState.port_mapping/1
    (excontainers 0.3.0) lib/docker/container_state.ex:28: Docker.ContainerState.parse_docker_response/1
    (excontainers 0.3.0) lib/docker/api/containers.ex:50: Docker.Api.Containers.inspect/1
Last message (from Excontainers.ResourcesReaper): {:mapped_port, 8080}
** (EXIT from #PID<0.93.0>) exited in: GenServer.call(#PID<0.554.0>, {:mapped_port, 8080}, 5000)
    ** (EXIT) an exception was raised:
        ** (BadMapError) expected a map, got: nil
            (elixir 1.16.3) lib/map.ex:535: Map.get(nil, "HostPort", nil)
            (excontainers 0.3.0) lib/docker/container_state.ex:34: anonymous fn/1 in Docker.ContainerState.port_mapping/1
            (elixir 1.16.3) lib/enum.ex:1708: anonymous fn/3 in Enum.map/2
            (stdlib 4.3.1.4) maps.erl:411: :maps.fold_1/3
            (elixir 1.16.3) lib/enum.ex:2540: Enum.map/2
            (excontainers 0.3.0) lib/docker/container_state.ex:34: Docker.ContainerState.port_mapping/1
            (excontainers 0.3.0) lib/docker/container_state.ex:28: Docker.ContainerState.parse_docker_response/1
            (excontainers 0.3.0) lib/docker/api/containers.ex:50: Docker.Api.Containers.inspect/1
```

I see this error very frequently with the `ResourcesReaper` container, but I don't think it's specific to that. Retrying after a small delay seems to consistently resolve the problem. This PR implements retry logic for all calls to `Docker.Containers.mapped_port/2`

As a side note, the tests are failing for me both with and without this change.