### PR TITLE
Fix license in hex.pm package metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Excontainers.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: [
         links: %{"GitHub" => @source_url},
-        licenses: ["GPL-3.0-or-later"]
+        licenses: ["MIT"]
       ],
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [


### PR DESCRIPTION
## Summary
- Updates the package license in mix.exs from GPL-3.0-or-later to MIT

The LICENSE file was updated to MIT in f47e636 but the package metadata in mix.exs was not updated, causing hex.pm to still show GPL-3.0-or-later.

## Test plan
- Verify mix.exs shows `licenses: ["MIT"]`
- After publishing, verify hex.pm shows MIT license